### PR TITLE
:heavy-plus-sign Mozilla Gateway Addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 ### Home Automation
 
 - [snipshue](https://github.com/snipsco/snips-skill-hue) - Control for Philips Hue lights
+- [Mozilla Gateway add-on](https://github.com/andrenatal/voice-addon/) - Integrates Snips with Mozilla's smart home software.
 
 ### Entertainment
 


### PR DESCRIPTION
By the way, shouldn't the Home Assistant component also be under Home Automation?